### PR TITLE
Updated rake deploy so that gems are installed before it's done updat…

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -8,7 +8,8 @@ end
 task :update do
   system 'git checkout master'
   system 'git pull origin master'
-  system 'raild db:migrate'
+  system 'bundle install'
+  system 'rails db:migrate'
 end
 
 task :shutdown do


### PR DESCRIPTION
…ing.

rails db:migrate was spelled wrong and added bundle install to the update task.
